### PR TITLE
bug-fixed-link-in-README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Apart from the AppWrite classes, this playground uses two open source dependenci
 
 All code contributions - including those of people having commit access - must go through a pull request and approved by a core developer before being merged. This is to ensure proper review of all the code.
 
-We truly ❤️ pull requests! If you wish to help, you can learn more about how you can contribute to this project in the [contribution guide]([CONTRIBUTING.md](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)).
+We truly ❤️ pull requests! If you wish to help, you can learn more about how you can contribute to this project in the [contribution guide](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md).
 
 ## Security
 


### PR DESCRIPTION
Fixed a bug which prevented the contributing guide link from showing up

Here's what the page looked like before:

![Screenshot 2020-10-01 at 8 25 03 PM](https://user-images.githubusercontent.com/56179878/94826146-a3e59d00-0424-11eb-8afa-ec0cb0741949.png)

Here's what it looks like now:

![Screenshot 2020-10-01 at 8 26 04 PM](https://user-images.githubusercontent.com/56179878/94826202-b233b900-0424-11eb-8f91-b7816b28a353.png)

I have verified that the link is working correctly.